### PR TITLE
fix(tRPC): handle the TRPCError on create

### DIFF
--- a/components/Search/ImageLayer.tsx
+++ b/components/Search/ImageLayer.tsx
@@ -95,59 +95,65 @@ export const DownloadButton: FC<DownloadButtonPops> = props => {
   );
 };
 
+type SubLayerProps = WithImageAndUserId &
+  WithChildren & {
+    linkProps?: LayerProps['linkProps'];
+    toggleAlbumModal: Function;
+  };
+const InnerImageLayer: FC<SubLayerProps> = props => {
+  const { image, userId, toggleAlbumModal, linkProps, children } = props;
+  const buttonProps = { userId, image, toggleAlbumModal };
+  return (
+    <Link {...linkProps} data-test="modal-link" className="relative">
+      {children}
+      <div className="image-layout-cover">
+        <SaveButton
+          {...buttonProps}
+          toggleAlbumModal={toggleAlbumModal}
+          className="cs-fixed absolute right-5 top-5"
+        />
+        <div className="absolute bottom-0 flex w-full items-center justify-between p-5">
+          <PhotographerName name={image.photographer} className="text-white" />
+          <DownloadButton {...buttonProps} content="icon" className="cs-fixed" />
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+const OuterImageLayer: FC<SubLayerProps> = ({ image, userId, toggleAlbumModal, children }) => {
+  const buttonProps = { userId, image, toggleAlbumModal };
+  return (
+    <div key={image.id}>
+      <PhotographerName name={image.photographer} className="block py-3 pl-1 text-white" />
+      {children}
+      <div className="flex w-full items-center justify-between px-2 pt-3">
+        <SaveButton {...buttonProps} className="cs-change" />
+        <DownloadButton {...buttonProps} content="text" className="cs-change" />
+      </div>
+    </div>
+  );
+};
+
 type LayerProps = {
   linkProps: any;
   hasMobileSize: boolean;
 } & WithImageAndUserId &
   WithChildren;
-
-const InnerImageLayer: FC<LayerProps> = ({ image, userId, linkProps, children }) => {
-  const { showAlbumModal, albumModalProps, toggleAlbumModal } = useAlbumModal(image, userId!);
-  return (
-    <AlbumModal show={showAlbumModal} toggle={toggleAlbumModal} {...albumModalProps}>
-      <Link {...linkProps} data-test="modal-link" className="relative">
-        {children}
-        <div className="image-layout-cover">
-          <SaveButton
-            {...albumModalProps}
-            toggleAlbumModal={toggleAlbumModal}
-            className="cs-fixed absolute right-5 top-5"
-          />
-          <div className="absolute bottom-0 flex w-full items-center justify-between p-5">
-            <PhotographerName name={image.photographer} className="text-white" />
-            <DownloadButton {...albumModalProps} content="icon" className="cs-fixed" />
-          </div>
-        </div>
-      </Link>
-    </AlbumModal>
-  );
-};
-
-const OuterImageLayer: FC<LayerProps> = ({ image, userId, children }) => {
-  const { showAlbumModal, albumModalProps, toggleAlbumModal } = useAlbumModal(image, userId!);
-  return (
-    <AlbumModal show={showAlbumModal} toggle={toggleAlbumModal} {...albumModalProps}>
-      <div key={image.id}>
-        <PhotographerName name={image.photographer} className="block py-3 pl-1 text-white" />
-        {children}
-        <div className="flex w-full items-center justify-between px-2 pt-3">
-          <SaveButton
-            {...albumModalProps}
-            toggleAlbumModal={toggleAlbumModal}
-            className="cs-change"
-          />
-          <DownloadButton {...albumModalProps} content="text" className="cs-change" />
-        </div>
-      </div>
-    </AlbumModal>
-  );
-};
-
 export const ImageLayer: FC<LayerProps> = props => {
   const { data: session } = useSession();
-  return props.hasMobileSize ? (
-    <OuterImageLayer userId={session?.user.id} {...props} />
-  ) : (
-    <InnerImageLayer userId={session?.user.id} {...props} />
+  const userId = session?.user.id;
+  const { image, linkProps, children } = props;
+  const { showAlbumModal, albumModalProps, toggleAlbumModal } = useAlbumModal(image, userId!);
+
+  const layerProps = { userId, image, linkProps, toggleAlbumModal, children };
+  return (
+    <AlbumModal show={showAlbumModal} toggle={toggleAlbumModal} {...albumModalProps}>
+      {props.hasMobileSize ? (
+        <OuterImageLayer {...layerProps} />
+      ) : (
+        <InnerImageLayer {...layerProps} />
+      )}
+    </AlbumModal>
   );
 };

--- a/server/router/dashboard/userAlbumsRouter.ts
+++ b/server/router/dashboard/userAlbumsRouter.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { db } from '@/server/db/client';
+import { TRPCError } from '@trpc/server';
 import { router, publicProcedure } from '@/server/trpc';
 
 const albums = db.album;
@@ -23,7 +24,11 @@ export const userAlbumRouter = router({
   }),
   addNewAlbum: publicProcedure.input(AlbumSchema).mutation(async ({ input }) => {
     const { name, userId } = input;
-    return await albums.create({ data: { name, user: { connect: { id: userId } } } });
+    try {
+      return await albums.create({ data: { name, user: { connect: { id: userId } } } });
+    } catch (error) {
+      throw new TRPCError({ code: 'UNPROCESSABLE_CONTENT', message: 'Already exists!' });
+    }
   }),
   renameAlbum: publicProcedure.input(AlbumRenameSchema).mutation(async ({ input }) => {
     const { name, userId, newName } = input;

--- a/server/router/dashboard/userImageRouter.ts
+++ b/server/router/dashboard/userImageRouter.ts
@@ -1,16 +1,16 @@
 import { z } from 'zod';
 import { db } from '@/server/db/client';
+import { TRPCError } from '@trpc/server';
 import { router, publicProcedure } from '@/server/trpc';
 import { ResponseImageSchema } from '@/utils/validation';
 
 const images = db.image;
 
-const ImageSchema = ResponseImageSchema.merge(
-  z.object({
-    userId: z.string(),
-    albumName: z.string()
-  })
-);
+const ImageSchema = z.object({
+  userId: z.string(),
+  albumName: z.string(),
+  image: ResponseImageSchema
+});
 
 const IdUserIdSchema = z.object({
   id: z.number(),
@@ -19,15 +19,20 @@ const IdUserIdSchema = z.object({
 
 export const userImageRouter = router({
   addNewImage: publicProcedure.input(ImageSchema).mutation(async ({ input }) => {
-    const { userId, albumName, photographer, ...image } = input;
-    return await images.create({
-      data: {
-        ...image,
-        user: { connect: { id: userId } },
-        album: { connect: { name_userId: { name: albumName, userId } } }
-      },
-      include: { album: true }
-    });
+    const { userId, albumName, image } = input;
+    const { photographer, ...userImage } = image;
+    try {
+      return await images.create({
+        data: {
+          ...userImage,
+          user: { connect: { id: userId } },
+          album: { connect: { name_userId: { name: albumName, userId } } }
+        },
+        include: { album: true }
+      });
+    } catch (error) {
+      return { error };
+    }
   }),
   deleteImage: publicProcedure.input(IdUserIdSchema).mutation(async ({ input: id_userId }) => {
     return await images.delete({ where: { id_userId } });


### PR DESCRIPTION
- - Remove the env variables
- ci: remove the push event
- fix(schema): update the image and album tables
- chore(tRPC): create the dashboard routers
- - Remove unnecessarily code
- - Create an individual file for getting the session in the server side
- chore(prisma): update prisma client
- fix(session): using getInitialProps to get the currentSession for the app layout
- - Fix the signup form
- chore(package): swich to pnpm
- test(Navbar): add a test for the navbar search input
- - Render the image blurhash in the ImageModal component
- - Update the edit section description
- feat(albums): create the album modal with the save button
- - Add the album modal custom hook
- - Add the album modal grid layout
- perf(session): get the user session in the server side
- chore(tRPC): add query client default options
- fix(tRPC): update the routers
- fix(schema): update the image table
- - Create resized image src function
- - Moving the album modal component
- fix(modal): move the album modal component to the global image layer
- fix(tRPC): handle the TRPCError on create
